### PR TITLE
To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -34,11 +34,11 @@ jobs:
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          github-token: "${{ secrets.dependabot_token }}"
+          GITHUB_TOKEN: ${{ secrets.dependabot_token }}
 
       - name: Run step gh pr merge --auto --squash
         if: ${{ steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' }}
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          github-token: "${{ secrets.dependabot_token }}"
+          GITHUB_TOKEN: ${{ secrets.dependabot_token }}


### PR DESCRIPTION
Fixes #7