### PR TITLE
Remove --auto flag from Dependabot merge step

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Pull request merge
         if: ${{ steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' }}
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: gh pr merge --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Problem

The `--auto` flag queues auto-merge and waits for all ruleset conditions to be satisfied before GitHub fires the merge. The `pr-approve-and-merge` app has `bypass_mode: pull_request` in the branch ruleset, but this bypass only applies when the app **directly calls the merge API** — not when auto-merge is evaluating conditions in the queue.

When `require_code_owner_review: true` is set and the bot is not a member of the code owner team, the required code owner review condition is never satisfied and auto-merge stalls indefinitely.

## Fix

Remove `--auto` so the bot merges directly via the API, invoking its ruleset bypass and completing the merge immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow automation configuration for dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->