### PR TITLE
Fix release title and skip if release already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.token }}
           TAG: ${{ github.ref_name }}
         run: |
+          gh release view $TAG --repo "${{ github.repository }}" > /dev/null 2>&1 && exit 0
           gh release create $TAG \
             --repo "${{ github.repository }}" \
             --title "$TAG" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,5 +20,5 @@ jobs:
         run: |
           gh release create $TAG \
             --repo "${{ github.repository }}" \
-            --title "${TAG#v}" \
+            --title "$TAG" \
             --generate-notes


### PR DESCRIPTION
Two fixes to the release workflow:

1. **Keep `v` prefix in release title** — `${TAG#v}` was stripping the `v`, so releases were titled `1.2.3` instead of `v1.2.3`.
2. **Skip silently if release already exists** — if a developer creates the release manually in the UI before the workflow runs, `gh release create` would fail because the tag already exists. Now it checks first and exits 0 if found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow robustness by adding checks before creating new releases, reducing potential conflicts during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->