### PR TITLE
Add permissions to workflows

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -49,6 +49,10 @@ on:
         type: string
 
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build-and-push:
     name: Build and push

--- a/.github/workflows/local-add-to-projects.yml
+++ b/.github/workflows/local-add-to-projects.yml
@@ -8,6 +8,7 @@ on:
     types:
       - opened
 
+permissions: {}
 
 jobs:
   add-to-osinfra-project:

--- a/.github/workflows/local-add-to-projects.yml
+++ b/.github/workflows/local-add-to-projects.yml
@@ -8,7 +8,8 @@ on:
     types:
       - opened
 
-permissions: {}
+permissions:
+  issues: write
 
 jobs:
   add-to-osinfra-project:

--- a/.github/workflows/local-dependabot.yml
+++ b/.github/workflows/local-dependabot.yml
@@ -2,6 +2,8 @@ name: Dependabot Approve and Merge
 
 on: pull_request_target
 
+permissions: {}
+
 jobs:
   dependabot:
     name: Dependabot

--- a/.github/workflows/nuclei.yml
+++ b/.github/workflows/nuclei.yml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+  security-events: write
 
 jobs:
   nuclei-scan:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,8 @@ on:
         description: The GitHub token
         required: true
 
-permissions: {}
+permissions:
+  contents: write
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
         description: The GitHub token
         required: true
 
+permissions: {}
 
 jobs:
   release:


### PR DESCRIPTION
Adds explicit `permissions` blocks to all workflows that were missing them.

| Workflow | Permissions |
|---|---|
| `release.yml` | `{}` (uses passed `secrets.token`, not implicit GITHUB_TOKEN) |
| `local-dependabot.yml` | `{}` (delegates entirely to called workflow) |
| `nuclei.yml` | `contents: read`, `security-events: write` |
| `local-add-to-projects.yml` | `{}` (delegates entirely to called workflow) |
| `build-and-push.yml` | `contents: read`, `id-token: write` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Applied explicit workflow-level permissions across CI and automation workflows to enforce least-privilege access.
  * Granted only required rights per workflow (examples: read-only repo contents, ID token write, issues write, security-events write, targeted contents write) to tighten token scopes and improve security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->