### PR TITLE
Restrict pull_request_target event types and normalize permissions

### DIFF
--- a/.github/workflows/local-dependabot.yml
+++ b/.github/workflows/local-dependabot.yml
@@ -1,8 +1,11 @@
 name: Dependabot Approve and Merge
 
-on: pull_request_target
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   dependabot:


### PR DESCRIPTION
## Summary

The `pull_request_target` trigger runs with base repository privileges and has access to repository secrets. Without explicit event type filters, it fires on all default PR event types.

This PR adds explicit `types: [opened, synchronize, reopened]` to the trigger (which was already the implicit default). Making it explicit:
- Documents the intended trigger scope
- Reduces the attack surface by being explicit rather than relying on defaults
- Follows the principle of explicit over implicit

Existing security mitigations remain in place:
- `github.actor == 'dependabot[bot]'` guard in the reusable called workflow
- No PR head code is checked out or executed
- Privileged operations use a GitHub App token, not `GITHUB_TOKEN`

### Additional change
Normalizes `permissions: {}` to `permissions: contents: read` for consistency with all other caller workflows that use this pattern.