### PR TITLE
Handle race condition when release is created manually before workflow runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.token }}
           TAG: ${{ github.ref_name }}
         run: |
-          gh release view $TAG --repo "${{ github.repository }}" > /dev/null 2>&1 && exit 0
-          gh release create $TAG \
+          if gh release view "$TAG" --repo "${{ github.repository }}" > /dev/null 2>&1; then
+            exit 0
+          fi
+          gh release create "$TAG" \
             --repo "${{ github.repository }}" \
             --title "$TAG" \
-            --generate-notes
+            --generate-notes || \
+          gh release view "$TAG" --repo "${{ github.repository }}" > /dev/null 2>&1


### PR DESCRIPTION
## What changed and why

The release workflow can fail with `HTTP 422: Release.tag_name already exists` when a release is created manually on GitHub.

The prior fix (`gh release view ... && exit 0`) handles the case where the release is already visible when the workflow starts. However, there is a race window: when a user creates a release manually, GitHub creates the tag first and then creates the release. The tag push triggers the workflow — `gh release view` runs before the release is reflected in the API, finds nothing, then `gh release create` fails because GitHub has since finished creating the release.

This PR adds a fallback: if `gh release create` fails, re-check with `gh release view`. If the release now exists, the step exits 0 (race condition resolved). If it still does not exist, the step fails as expected for genuine errors.

Also quotes `$TAG` consistently throughout the script.

Closes #187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release creation safeguards to prevent duplicate releases.
  * Added a fallback for cases where automatic release note generation fails.
  * Improved handling of release identifiers and metadata during publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->